### PR TITLE
Lower volume levels

### DIFF
--- a/odroid-go-common/components/odroid/odroid_audio.c
+++ b/odroid-go-common/components/odroid/odroid_audio.c
@@ -14,7 +14,7 @@
 
 static float Volume = 1.0f;
 static odroid_volume_level volumeLevel = ODROID_VOLUME_LEVEL3;
-static int volumeLevels[] = {0, 150, 500, 1000};
+static int volumeLevels[] = {0, 75, 400, 1000};
 static int audio_sample_rate;
 
 


### PR DESCRIPTION
I'm not sure if these values will work but I wanted to propose spreading out the volume levels a little more. The loudest setting is fine for very noisy environments but the mid and low settings could be lower in my opinion. The most important change is to the low setting since it just seems a bit too loud for a quiet environment where you want sound but don't want it overly loud.